### PR TITLE
Update kodi_tv.m3u

### DIFF
--- a/iptv/kodi/kodi_tv.m3u
+++ b/iptv/kodi/kodi_tv.m3u
@@ -10,7 +10,7 @@ https://artelive-lh.akamaihd.net/i/artelive_de@393591/index_1_av-p.m3u8
 #EXTINF:-1 tvg-name="ServusTV HD" tvg-id="ServusHD.de" group-title="Spartenprogramm" tvg-logo="https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/servustvhd.png",ServusTV HD
 https://rbmn-live.akamaized.net/hls/live/2002830/geoSTVDEweb/master_6692.m3u8
 #EXTINF:-1 tvg-name="ARD-alpha" tvg-id="ARD-alpha.de" group-title="Spartenprogramm" tvg-logo="https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/ardalpha.png",ARD-alpha
-https://brlive-lh.akamaihd.net/i/bralpha_germany@119899/index_1_av-p.m3u8
+https://brlive-lh.akamaihd.net/i/bralpha_germany@119899/master.m3u8
 #EXTINF:-1 tvg-name="one HD" tvg-id="One.de" group-title="Spartenprogramm" tvg-logo="https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/onehd.png",one HD
 https://onelivestream-lh.akamaihd.net/i/one_livestream@568814/index_4_av-p.m3u8
 #EXTINF:-1 tvg-name="ZDFneo HD" tvg-id="ZDFneo.de" group-title="Spartenprogramm" tvg-logo="https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/zdfneohd.png",ZDFneo HD


### PR DESCRIPTION
Replaced new working URL for ARD-alpha:
https://brlive-lh.akamaihd.net/i/bralpha_germany@119899/master.m3u8
also possible for 720 lines: https://brlive-lh.akamaihd.net/i/bralpha_germany@119899/index_3660_av-p.m3u8?sd=10&rebase=on
or for 270 lines: https://brlive-lh.akamaihd.net/i/bralpha_germany@119899/index_578_av-p.m3u8?sd=10&rebase=on