### PR TITLE
Noch ein Fix für NDR

### DIFF
--- a/iptv/source.yaml
+++ b/iptv/source.yaml
@@ -4276,7 +4276,7 @@ tv:
         tvg_id: ndr.de
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/ndrhd.png
         tvg_name: NDR Niedersachsen HD
-        url: https://mcdn.ndr.de/ndr/hls/ndr_fs/ndr_nds/master.m3u8
+        url: https://mcdn.ndr.de/ndr/hls/ndr_fs/ndr_nds/master_720.m3u8
       - group_title: IPTV-DE
         group_title_kodi: Regional
         name: NDR Schleswig-Holstein HD
@@ -4285,7 +4285,7 @@ tv:
         tvg_id: ndr.de
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/ndrhd.png
         tvg_name: NDR Schleswig-Holstein HD
-        url: https://ndrfs-lh.akamaihd.net/i/ndrfs_sh@430234/index_3712_av-p.m3u8
+        url: https://ndrfs-lh.akamaihd.net/i/ndrfs_sh@430234/index_3712_av-b.m3u8
       - group_title: IPTV-DE
         group_title_kodi: Regional
         name: NDR Mecklenburg-Vorpommern HD
@@ -4294,7 +4294,7 @@ tv:
         tvg_id: ndr.de
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/ndrhd.png
         tvg_name: NDR Mecklenburg-Vorpommern HD
-        url: https://mcdn.ndr.de/ndr/hls/ndr_fs/ndr_mv/master.m3u8
+        url: https://mcdn-ndr.akamaized.net/ndr/hls/ndr_fs/ndr_mv/master_720.m3u8
       - group_title: IPTV-DE
         group_title_kodi: Regional
         name: NDR Hamburg HD
@@ -4303,7 +4303,7 @@ tv:
         tvg_id: ndr.de
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/ndrhd.png
         tvg_name: NDR Hamburg HD
-        url: https://ndrfs-lh.akamaihd.net/i/ndrfs_hh@430231/master.m3u8
+        url: https://ndrfs-lh.akamaihd.net/i/ndrfs_hh@430231/index_3712_av-b.m3u8
       - group_title: IPTV-DE
         group_title_kodi: Regional
         name: Radio Bremen TV HD


### PR DESCRIPTION
Beim letzten Update für Arte wurden die alten NDR Adresse aus irgendeinem Grund mit in den Commit gepackt.
War mein Fehler. habe die jetzt hoffentlich wieder richtig hinzugefügt.

Sorry.