### PR TITLE
Fix RADIO ENERGY Sachsen

### DIFF
--- a/iptv/source.yaml
+++ b/iptv/source.yaml
@@ -1501,7 +1501,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/radioenergysachsen.png
         tvg_name: RADIO ENERGY Sachsen
-        url: http://nrj.de/sachsen
+        url: https://scdn.nrjaudio.fm/adwz1/de/33013/mp3_128.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: Radio Horeb


### PR DESCRIPTION
With mpv, the current URL doesn't work (tls error).

This follows only the 301 permanent redirect from the previous
http://nrj.de/sachsen to https://scdn.nrjaudio.fm/adwz1/de/33013/mp3_128.mp3