### PR TITLE
CDN-Wechsel der öffentlich-rechtlichen Sender

### DIFF
--- a/iptv/source.yaml
+++ b/iptv/source.yaml
@@ -405,7 +405,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/bayern1.png
         tvg_name: Bayern 1 Mittel- und Oberfranken
-        url: https://br-br1-franken.cast.addradio.de/br/br1/franken/mp3/mid
+        url: https://dispatcher.rndfnk.com/br/br1/franken/mp3/mid
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: Bayern 1 Mainfranken
@@ -414,7 +414,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/bayern1.png
         tvg_name: Bayern 1 Mainfranken
-        url: https://br-br1-mainfranken.cast.addradio.de/br/br1/mainfranken/mp3/mid
+        url: https://dispatcher.rndfnk.com/br/br1/mainfranken/mp3/mid
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: Bayern 1 Oberbayern
@@ -423,7 +423,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/bayern1.png
         tvg_name: Bayern 1 Oberbayern
-        url: https://br-br1-obb.cast.addradio.de/br/br1/obb/mp3/mid
+        url: https://dispatcher.rndfnk.com/br/br1/obb/mp3/mid
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: Bayern 1 Niederbayern und Oberpfalz
@@ -432,7 +432,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/bayern1.png
         tvg_name: Bayern 1 Niederbayern und Oberpfalz
-        url: https://br-br1-nbopf.cast.addradio.de/br/br1/nbopf/mp3/mid
+        url: https://dispatcher.rndfnk.com/br/br1/nbopf/mp3/mid
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: Bayern 1 Schwaben
@@ -441,7 +441,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/bayern1.png
         tvg_name: Bayern 1 Schwaben
-        url: https://br-br1-schwaben.cast.addradio.de/br/br1/schwaben/mp3/mid
+        url: https://dispatcher.rndfnk.com/br/br1/schwaben/mp3/mid
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: Bayern 2 Nord
@@ -450,7 +450,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/bayern2.png
         tvg_name: Bayern 2 Nord
-        url: https://br-br2-nord.cast.addradio.de/br/br2/nord/mp3/mid
+        url: https://dispatcher.rndfnk.com/br/br2/nord/mp3/mid
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: Bayern 2 Süd
@@ -459,7 +459,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/bayern2.png
         tvg_name: Bayern 2 Süd
-        url: https://br-br2-sued.cast.addradio.de/br/br2/sued/mp3/mid
+        url: https://dispatcher.rndfnk.com/br/br2/sued/mp3/mid
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: Bayern 3
@@ -468,7 +468,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/bayern3.png
         tvg_name: Bayern 3
-        url: http://br-br3-live.cast.addradio.de/br/br3/live/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/br/br3/live/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: Bayern plus
@@ -504,7 +504,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/brheimat.png
         tvg_name: BR Heimat
-        url: https://br-brheimat-live.cast.addradio.de/br/brheimat/live/mp3/mid
+        url: https://dispatcher.rndfnk.com/br/brheimat/live/mp3/mid
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: BR-Klassik
@@ -522,7 +522,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/bremeneins.png
         tvg_name: Bremen Eins
-        url: http://rb-bremeneins-live.cast.addradio.de/rb/bremeneins/live/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/rb/bremeneins/live/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: Bremen Vier
@@ -531,7 +531,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/bremenvier.png
         tvg_name: Bremen Vier
-        url: http://rb-bremenvier-live.cast.addradio.de/rb/bremenvier/live/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/rb/bremenvier/live/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: Bremen Vier rockt
@@ -549,7 +549,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/bremenzwei.png
         tvg_name: Bremen Zwei
-        url: http://rb-bremenzwei-live.cast.addradio.de/rb/bremenzwei/live/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/rb/bremenzwei/live/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: Campusradio Köln (Kölncampus)
@@ -594,7 +594,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/dasding.png
         tvg_name: DASDING
-        url: https://swr-dasding-live.sslcast.addradio.de/swr/dasding/live/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/swr/dasding/live/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: DELUXE 80S EXTREME
@@ -819,7 +819,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/hr1.png
         tvg_name: hr1
-        url: http://hr-hr1-live.cast.addradio.de/hr/hr1/live/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/hr/hr1/live/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: hr2-kultur
@@ -828,7 +828,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/hr2kultur.png
         tvg_name: hr2-kultur
-        url: http://hr-hr2-live.cast.addradio.de/hr/hr2/live/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/hr/hr2/live/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: hr3
@@ -837,7 +837,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/hr3.png
         tvg_name: hr3
-        url: http://hr-hr3-live.cast.addradio.de/hr/hr3/live/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/hr/hr3/live/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: hr4
@@ -846,7 +846,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/hr4.png
         tvg_name: hr4
-        url: http://hr-hr4-live.cast.addradio.de/hr/hr4/live/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/hr/hr4/live/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: JAM FM
@@ -999,7 +999,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/njoy.png
         tvg_name: N-JOY
-        url: http://ndr-njoy-live.cast.addradio.de/ndr/njoy/live/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/ndr/njoy/live/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: NDR 1 Niedersachsen
@@ -1008,7 +1008,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/ndr1niedersachsen.png
         tvg_name: NDR 1 Niedersachsen
-        url: http://ndr-ndr1niedersachsen-hannover.cast.addradio.de/ndr/ndr1niedersachsen/hannover/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/ndr/ndr1niedersachsen/hannover/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: NDR 1 Radio MV
@@ -1017,7 +1017,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/ndr1radiomv.png
         tvg_name: NDR 1 Radio MV
-        url: http://ndr-ndr1radiomv-schwerin.cast.addradio.de/ndr/ndr1radiomv/schwerin/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/ndr/ndr1radiomv/schwerin/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: NDR 1 Welle Nord
@@ -1026,7 +1026,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/ndr1wellenord.png
         tvg_name: NDR 1 Welle Nord
-        url: http://ndr-ndr1wellenord-kiel.cast.addradio.de/ndr/ndr1wellenord/kiel/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/ndr/ndr1wellenord/kiel/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: NDR 2
@@ -1035,7 +1035,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/ndr2.png
         tvg_name: NDR 2
-        url: http://ndr-ndr2-niedersachsen.cast.addradio.de/ndr/ndr2/niedersachsen/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/ndr/ndr2/niedersachsen/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: NDR 90.3
@@ -1044,7 +1044,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/ndr903.png
         tvg_name: NDR 90.3
-        url: http://ndr-ndr903-hamburg.cast.addradio.de/ndr/ndr903/hamburg/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/ndr/ndr903/hamburg/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: NDR Blue
@@ -1053,7 +1053,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/ndrblue.png
         tvg_name: NDR Blue
-        url: http://ndr-ndrblue-live.cast.addradio.de/ndr/ndrblue/live/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/ndr/ndrblue/live/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: NDR Info
@@ -1062,7 +1062,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/ndrinfo.png
         tvg_name: NDR Info
-        url: http://ndr-ndrinfo-niedersachsen.cast.addradio.de/ndr/ndrinfo/niedersachsen/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/ndr/ndrinfo/niedersachsen/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: NDR Info Spezial
@@ -1071,7 +1071,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/ndrinfospezial.png
         tvg_name: NDR Info Spezial
-        url: http://ndr-ndrinfospezial-live.cast.addradio.de/ndr/ndrinfospezial/live/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/ndr/ndrinfospezial/live/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: NDR kultur
@@ -1080,7 +1080,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/ndrkultur.png
         tvg_name: NDR kultur
-        url: http://ndr-ndrkultur-live.cast.addradio.de/ndr/ndrkultur/live/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/ndr/ndrkultur/live/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: NDR Plus
@@ -1089,7 +1089,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/ndrplus.png
         tvg_name: NDR Plus
-        url: http://ndr-ndrplus-live.cast.addradio.de/ndr/ndrplus/live/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/ndr/ndrplus/live/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: nice
@@ -1134,7 +1134,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/puls.png
         tvg_name: PULS
-        url: https://br-puls-live.cast.addradio.de/br/puls/live/mp3/mid
+        url: https://dispatcher.rndfnk.com/br/puls/live/mp3/mid
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: Radio 7
@@ -1672,7 +1672,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/swr1.png
         tvg_name: SWR1 Baden-Württemberg
-        url: http://swr-swr1-bw.cast.addradio.de/swr/swr1/bw/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/swr/swr1/bw/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: SWR1 Rheinland-Pfalz
@@ -1681,7 +1681,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/swr1.png
         tvg_name: SWR1 Rheinland-Pfalz
-        url: http://swr-swr1-rp.cast.addradio.de/swr/swr1/rp/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/swr/swr1/rp/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: SWR2
@@ -1690,7 +1690,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/swr2.png
         tvg_name: SWR2
-        url: http://swr-swr2-live.cast.addradio.de/swr/swr2/live/mp3/256/stream.mp3
+        url: https://dispatcher.rndfnk.com/swr/swr2/live/mp3/256/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: SWR3
@@ -1699,7 +1699,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/swr3.png
         tvg_name: SWR3
-        url: http://swr-swr3-live.cast.addradio.de/swr/swr3/live/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/swr/swr3/live/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: SWR4 Baden-Württemberg
@@ -1708,7 +1708,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/swr4.png
         tvg_name: SWR4 Baden-Württemberg
-        url: http://swr-swr4-bw.cast.addradio.de/swr/swr4/bw/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/swr/swr4/bw/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: SWR4 Rheinland-Pfalz
@@ -1717,7 +1717,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/swr4.png
         tvg_name: SWR4 Rheinland-Pfalz
-        url: http://swr-swr4-rp.cast.addradio.de/swr/swr4/rp/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/swr/swr4/rp/mp3/128/stream.mp3
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: UNSERDING
@@ -1771,7 +1771,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/youfm.png
         tvg_name: YOU FM
-        url: http://hr-youfm-live.cast.addradio.de/hr/youfm/live/mp3/128/stream.mp3
+        url: https://dispatcher.rndfnk.com/hr/youfm/live/mp3/128/stream.mp3
     it:
       id: 9
       streams:


### PR DESCRIPTION
Zum 01.09.2021 wurde der Wechsel des CDNs von addradio.de
zu rndfnk.com für (fast) alle öffenlich-rechtlichen Sender
vollzogen. Der Pfad der URLs blieb dabei identisch, nur der Hostname
ändert sich von *.addradio.de zu dispatcher.rndfnk.com.
Siehe https://www.br.de/unternehmen/inhalt/technik/livestreams-hilfe100.html

Daher wurden zunächst alle URLs mit
`sed -i -E 's@https?://.+\.addradio\.de/(.*)@https://dispatcher.rndfnk.com/\1@' iptv/source.yaml`
geändert und bei Nichtverfügbarkeit zurückgeändert.

BR:
Damit funktionieren die Angebote des BR wieder.

RBB:
Der RBB hat den Wechsel wohl noch nicht vollzogen, dort funktionieren
nur die alten Adressen.

HRinfo:
Dieser Kanal wird auf dem neuen CDN nicht mehr im davor verwendeten Format mp3/128
ausgestrahlt. Die offiziellen Links unter
https://www.hr.de/services/empfang-und-verbreitungswege/web-radio-und-web-tv,empfang-internet-100.html
führen zu m3u-Dateien, die auf Streams in 48 oder 96 kbit/s Qualität
(MP3/AAC) verweisen. Daher wird zunächst der alte Link beibehalten.

Bremen Vier rockt:
Dieser (Event?-)Sender steht unter der alten URL aktuell zur Verfügung,
die neue URL gibt ein 503 Service Unavailable sowie eine Webseite
zurück, die angeben, dass aktuell nicht gesendet wird.
Aufgrund der unklaren Situation verbleibt zunächst der alte Link.

Private Sender:
ERF sowie Die Neue 107.7 werden ebenfalls über addradio.de ausgestrahlt,
für diese Sender gilt der Wechsel natürlich nicht.