### PR TITLE
Update CONTRIBUTING.md regarding preferred stream quality

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,9 @@ Viele Streams, die als `master.m3u8` verfübar sind, bieten direkte Links mit ve
 
 ```
 https://mcdn.daserste.de/daserste/de/master.m3u8
--> https://mcdn.daserste.de/daserste/de/master_480p_828.m3u8 (480p)
--> ...
--> https://mcdn.daserste.de/daserste/de/master_1920p_5128.m3u8 (1080p)
+> https://mcdn.daserste.de/daserste/de/master_640p_828.m3u8 (640x360)
+> ...
+> https://mcdn.daserste.de/daserste/de/master_1920p_5128.m3u8 (1920x1080)
 ```
 
 Das initiale Laden der Direktlinks kann je nach Programm zwar zu schnelleren initialen Ladezeiten führen, verhindert aber auch die Nutzung von niedrigeren Auflösungen (z.B. bei langsameren Verbindungen).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,27 @@ Es ist nicht erforderlich, das Repository auszuchecken. Alle Änderungen können
 
 1. Repository forken
 2. Im Fork einen neuen Branch anlegen
-3. Änderungen in `iptv/source.yaml` einbauen (z.B. URL ändern)
+3. Änderungen in `iptv/source.yaml` einbauen (z.B. URL ändern) - siehe [Hinweis](#-Hinweis)
 4. Pull Request erstellen (Titel z.B. "Fix ..." oder "Add ...")
+
+# Hinweis
+Wenn Streams in mehreren Qualitäten verfügbar sind, bitte immer den `master.m3u8`-Stream verwenden!
+
+<details>
+<summary>Klicke hier für Begründung</summary>
+<br>
+Viele Streams, die als `master.m3u8` verfübar sind, bieten direkte Links mit verschiedenen Auflösungen an:
+
+```
+https://mcdn.daserste.de/daserste/de/master.m3u8
+-> https://mcdn.daserste.de/daserste/de/master_480p_828.m3u8 (480p)
+-> ...
+-> https://mcdn.daserste.de/daserste/de/master_1920p_5128.m3u8 (1080p)
+```
+
+Das initiale Laden der Direktlinks kann je nach Programm zwar zu schnelleren initialen Ladezeiten führen, verhindert aber auch die Nutzung von niedrigeren Auflösungen (z.B. bei langsameren Verbindungen).
+
+Zudem werden Direktlinks deutlich häufiger vom Provider umbenannt/ersetzt, als dies bei `master`-Links der Fall ist. Die Nutzung von Direktlinks erfordert daher einen deutlich höheren Aufwand der Listenpflege.
 
 # Links
 - [GitHub - Mitwirken an einem Projekt](https://git-scm.com/book/de/v2/GitHub-Mitwirken-an-einem-Projekt)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,10 @@ Es ist nicht erforderlich, das Repository auszuchecken. Alle Änderungen können
 
 1. Repository forken
 2. Im Fork einen neuen Branch anlegen
-3. Änderungen in `iptv/source.yaml` einbauen (z.B. URL ändern) - siehe [Hinweis](#-Hinweis)
+3. Änderungen in `iptv/source.yaml` einbauen (z.B. URL ändern) - siehe [Hinweis](##-Hinweis)
 4. Pull Request erstellen (Titel z.B. "Fix ..." oder "Add ...")
 
-# Hinweis
+## Hinweis
 Wenn Streams in mehreren Qualitäten verfügbar sind, bitte immer den `master.m3u8`-Stream verwenden!
 
 <details>
@@ -25,6 +25,7 @@ https://mcdn.daserste.de/daserste/de/master.m3u8
 Das initiale Laden der Direktlinks kann je nach Programm zwar zu schnelleren initialen Ladezeiten führen, verhindert aber auch die Nutzung von niedrigeren Auflösungen (z.B. bei langsameren Verbindungen).
 
 Zudem werden Direktlinks deutlich häufiger vom Provider umbenannt/ersetzt, als dies bei `master`-Links der Fall ist. Die Nutzung von Direktlinks erfordert daher einen deutlich höheren Aufwand der Listenpflege.
+</details>
 
 # Links
 - [GitHub - Mitwirken an einem Projekt](https://git-scm.com/book/de/v2/GitHub-Mitwirken-an-einem-Projekt)


### PR DESCRIPTION
As stated in #570, the current requirements for new/updated streams were not clearly defined before.

This PR updates the **CONTRIBUTING.md** file regarding the stream quality (i.e. master vs. direct streams: 1080p, 720p, ...):

- If available, only use `master` streams for new/updated streams.
- Short description and example added.