### PR TITLE
Fix BlackBeats.FM URL

### DIFF
--- a/iptv/source.yaml
+++ b/iptv/source.yaml
@@ -486,7 +486,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/blackbeatsfm.png
         tvg_name: BlackBeats.FM
-        url: http://stream.blackbeatslive.de/
+        url: http://blackbeats.fm/listen.m3u
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: BR Heimat


### PR DESCRIPTION
The previous URL http://stream.blackbeatslive.de/ gives HTTP errors. Instead use the official m3u containing alternative URLs, among them http://stream.blackbeats.fm/