### PR TITLE
Fix Köln Campus radio URL

### DIFF
--- a/iptv/source.yaml
+++ b/iptv/source.yaml
@@ -549,7 +549,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/koelncampus.png
         tvg_name: Campusradio Köln (Kölncampus)
-        url: http://koelncampus.uni-koeln.de:80/hq
+        url: https://live.koelncampus.com/live
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: Campusradio Münster (Radio Q)


### PR DESCRIPTION
The new URL was found at https://www.koelncampus.com/sender/livestream/