### PR TITLE
Fix ERF URLs & rename

### DIFF
--- a/iptv/source.yaml
+++ b/iptv/source.yaml
@@ -747,16 +747,16 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/erfplus.png
         tvg_name: ERF Plus
-        url: http://erf1a64-ice-edge-1106-fra-eco-cdn.cast.addradio.de/erf1a64/live/mp3/high
+        url: https://stream.erf.de/erfplus.m3u
       - group_title: Radio-DE
         group_title_kodi: Deutschland
-        name: ERF Pop
+        name: ERF Jess
         quality: ''
         radio: true
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/erfpop.png
-        tvg_name: ERF Pop
-        url: http://erf1068-ice-edge-1103-fra-eco-cdn.cast.addradio.de/erf1068/live/mp3/high
+        tvg_name: ERF Jess
+        url: https://stream.erf.de/erfpop.m3u
       - group_title: Radio-DE
         group_title_kodi: Deutschland
         name: FluxFM


### PR DESCRIPTION
Use the official m3u's from https://www.erf.de/hoeren-sehen/empfang/8628 (HTTPS by me).

Additionally rename ERF Pop to ERF Jess (see https://de.wikipedia.org/wiki/ERF_Jess#Geschichte )