### PR TITLE
Fix Radio Manela URL

### DIFF
--- a/iptv/source.yaml
+++ b/iptv/source.yaml
@@ -2440,7 +2440,7 @@ radio:
         tvg_id: ''
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/radio/radiomanele.png
         tvg_name: Radio Manele
-        url: https://radio.ascultatare.ro/8044/stream
+        url: https://ssl.servereradio.ro/8044/stream
     uk:
       id: 4
       streams:


### PR DESCRIPTION
The previous URL gave a HTML error page.

The new URL was found at https://myradioonline.ro/fm-radio-manele