### PR TITLE
Fixed WDR Köln URL & enhanced tvg_name and tvg_id for WDR regional stations

### DIFF
--- a/iptv/source.yaml
+++ b/iptv/source.yaml
@@ -5746,99 +5746,99 @@ tv:
         name: WDR Aachen HD
         quality: hd
         radio: false
-        tvg_id: WDRFernsehen.de
+        tvg_id: WDRFernsehenAachen.de
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/wdrhd.png
-        tvg_name: WDR HD
+        tvg_name: WDR Aachen HD
         url: https://wdrlokalzeit.akamaized.net/hls/live/2018019-b/wdrlz_aachen/master.m3u8
       - group_title: IPTV-DE
         group_title_kodi: Regional
         name: WDR Bonn HD
         quality: hd
         radio: false
-        tvg_id: WDRFernsehen.de
+        tvg_id: WDRFernsehenBonn.de
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/wdrhd.png
-        tvg_name: WDR HD
+        tvg_name: WDR Bonn HD
         url: https://wdrlokalzeit.akamaized.net/hls/live/2018021-b/wdrlz_bonn/master.m3u8
       - group_title: IPTV-DE
         group_title_kodi: Regional
         name: WDR Bergisches Land HD
         quality: hd
         radio: false
-        tvg_id: WDRFernsehen.de
+        tvg_id: WDRFernsehenWuppertal.de
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/wdrhd.png
-        tvg_name: WDR HD
+        tvg_name: WDR Wuppertal HD
         url: https://wdrlokalzeit.akamaized.net/hls/live/2018028-b/wdrlz_wuppertal/master.m3u8
       - group_title: IPTV-DE
         group_title_kodi: Regional
         name: WDR Dortmund HD
         quality: hd
         radio: false
-        tvg_id: WDRFernsehen.de
+        tvg_id: WDRFernsehenDortmund.de
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/wdrhd.png
-        tvg_name: WDR HD
+        tvg_name: WDR Dortmund HD
         url: https://wdrlokalzeit.akamaized.net/hls/live/2018022-b/wdrlz_dortmund/master.m3u8
       - group_title: IPTV-DE
         group_title_kodi: Regional
         name: WDR Düsseldorf HD
         quality: hd
         radio: false
-        tvg_id: WDRFernsehen.de
+        tvg_id: WDRFernsehenDusseldorf.de
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/wdrhd.png
-        tvg_name: WDR HD
+        tvg_name: WDR Düsseldorf HD
         url: https://wdrlokalzeit.akamaized.net/hls/live/2018023-b/wdrlz_duesseldorf/master.m3u8
       - group_title: IPTV-DE
         group_title_kodi: Regional
         name: WDR Duisburg HD
         quality: hd
         radio: false
-        tvg_id: WDRFernsehen.de
+        tvg_id: WDRFernsehenDuisburg.de
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/wdrhd.png
-        tvg_name: WDR HD
+        tvg_name: WDR DuisburgHD
         url: https://wdrlokalzeit.akamaized.net/hls/live/2018024-b/wdrlz_duisburg/master.m3u8
       - group_title: IPTV-DE
         group_title_kodi: Regional
         name: WDR Köln HD
         quality: hd
         radio: false
-        tvg_id: WDRFernsehen.de
+        tvg_id: WDRFernsehenKoln.de
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/wdrhd.png
-        tvg_name: WDR HD
+        tvg_name: WDR Köln HD
         url: https://wdrlokalzeit.akamaized.net/hls/live/2023550-b/wdrlz_koeln/master.m3u8
       - group_title: IPTV-DE
         group_title_kodi: Regional
         name: WDR Münsterland HD
         quality: hd
         radio: false
-        tvg_id: WDRFernsehen.de
+        tvg_id: WDRFernsehenMunster.de
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/wdrhd.png
-        tvg_name: WDR HD
+        tvg_name: WDR Münster HD
         url: https://wdrlokalzeit.akamaized.net/hls/live/2018025-b/wdrlz_muensterland/master.m3u8
       - group_title: IPTV-DE
         group_title_kodi: Regional
         name: WDR Ostwestfalen HD
         quality: hd
         radio: false
-        tvg_id: WDRFernsehen.de
+        tvg_id: WDRFernsehenBielefeld.de
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/wdrhd.png
-        tvg_name: WDR HD
+        tvg_name: WDR Bielefeld HD
         url: https://wdrlokalzeit.akamaized.net/hls/live/2018026-b/wdrlz_bielefeld/master.m3u8
       - group_title: IPTV-DE
         group_title_kodi: Regional
         name: WDR Südwestfalen HD
         quality: hd
         radio: false
-        tvg_id: WDRFernsehen.de
+        tvg_id: WDRFernsehenSiegen.de
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/wdrhd.png
-        tvg_name: WDR HD
+        tvg_name: WDR Siegen HD
         url: https://wdrlokalzeit.akamaized.net/hls/live/2018020-b/wdrlz_siegen/master.m3u8
       - group_title: IPTV-DE
         group_title_kodi: Regional
         name: WDR Ruhr HD
         quality: hd
         radio: false
-        tvg_id: WDRFernsehen.de
+        tvg_id: WDRFernsehenEssen.de
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/wdrhd.png
-        tvg_name: WDR HD
+        tvg_name: WDR Essen HD
         url: https://wdrlokalzeit.akamaized.net/hls/live/2018027-b/wdrlz_essen/master.m3u8
       - group_title: IPTV-DE
         group_title_kodi: Regional

--- a/iptv/source.yaml
+++ b/iptv/source.yaml
@@ -5803,7 +5803,7 @@ tv:
         tvg_id: WDRFernsehenKoln.de
         tvg_logo: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/wdrhd.png
         tvg_name: WDR Köln HD
-        url: https://wdrlokalzeit.akamaized.net/hls/live/2023550-b/wdrlz_koeln/master.m3u8
+        url: https://wdr-live.ard-mcdn.de/wdr/live/hls/de/master.m3u8
       - group_title: IPTV-DE
         group_title_kodi: Regional
         name: WDR Münsterland HD


### PR DESCRIPTION
a) Fixed WDR Köln URL to working URL (taken from current webpage: https://www1.wdr.de/lokalzeit/fernsehen/livestream-lokalzeit-aus-koeln-104.html)

b) Enhanced tvg_name and tvg_id for WDR regional stations differentiation.